### PR TITLE
Solved overlapping events when zooming

### DIFF
--- a/mtv-client/src/components/Timeseries/Overview/DrawChart.tsx
+++ b/mtv-client/src/components/Timeseries/Overview/DrawChart.tsx
@@ -25,7 +25,7 @@ class DrawChart extends Component<Props> {
     if (JSON.stringify(prevProps.selectedPeriod) !== JSON.stringify(selectedPeriod)) {
       updateBrushPeriod(selectedPeriod);
     }
-    if (prevProps.datarun !== this.props.dataRun) {
+    if (prevProps.dataRun.eventWindows !== this.props.dataRun.eventWindows) {
       updateHighlithedEvents(this.props.dataRun);
     }
   }

--- a/mtv-client/src/components/Timeseries/Overview/chartUtils.ts
+++ b/mtv-client/src/components/Timeseries/Overview/chartUtils.ts
@@ -138,14 +138,15 @@ export function drawChart(width, height, dataRun, onPeriodTimeChange) {
     .attr('width', width)
     .attr('class', 'wave-chart');
 
-  svg
+  const eventWrapper = svg.append('g').attr('class', 'event-wrapper');
+  eventWrapper
     .append('path')
     .attr('class', 'wave-data')
     .attr('d', line(timeSeries))
     .attr('transform', `translate(${offset.left}, ${offset.top})`);
 
   highlightedEvents.forEach(event =>
-    svg
+    eventWrapper
       .append('path')
       .attr('class', 'wave-event')
       .attr('id', `wawe_${event.eventID}`)
@@ -170,7 +171,7 @@ export function updateHighlithedEvents(datarun) {
   }));
 
   const { xCoord, yCoord } = getScale(chartWidth, 36, datarun);
-  const svg = d3.select(`#_${datarun.id}`);
+  const svg = d3.select(`#_${datarun.id} .event-wrapper`);
   const line = d3
     .line()
     .x(d => xCoord(d[0]))

--- a/mtv-client/src/model/types/datarun.ts
+++ b/mtv-client/src/model/types/datarun.ts
@@ -76,6 +76,7 @@ export type DatarunDataType = {
     timestamp: number;
     data: { means: number[]; counts: number[] }[][];
   }[];
+  eventWindows?: any;
 };
 
 /**


### PR DESCRIPTION
When performing an event filtering or focuschart zoom, highlighter events from the linechart where overlapping the brush.

Solved.